### PR TITLE
Fix for go vet context leak warning added in go1.8

### DIFF
--- a/tmpl/transport-client.tmpl
+++ b/tmpl/transport-client.tmpl
@@ -35,14 +35,14 @@ type client{{.InterfaceName}} struct {
 func ({{.LocalName}} client{{.InterfaceName}}) {{.MethodName}}({{.MethodArguments}}) ({{.MethodResults}}) {
 	{{if .HasContextParam}}
 	if _, ok := {{.ContextParamName}}.Deadline(); !ok {
-		tmpctx, c := context.WithTimeout({{.ContextParamName}}, DefaultRequestTimeout)
-		{{.ContextParamName}} = tmpctx
-		defer c()
+		_tmpCtx, _ctxCancelFunc := context.WithTimeout({{.ContextParamName}}, DefaultRequestTimeout)
+		{{.ContextParamName}} = _tmpCtx
+		defer _ctxCancelFunc()
 	}
 	{{else}}
 	{{.ContextParamName}} := context.Background()
-	{{.ContextParamName}}, c := context.WithTimeout({{.ContextParamName}}, DefaultRequestTimeout)
-	defer c() 
+	{{.ContextParamName}}, _ctxCancelFunc := context.WithTimeout({{.ContextParamName}}, DefaultRequestTimeout)
+	defer _ctxCancelFunc() 
 	{{end}}
 
 	_request := {{.MethodNameLcase}}Request{

--- a/tmpl/transport-client.tmpl
+++ b/tmpl/transport-client.tmpl
@@ -35,10 +35,14 @@ type client{{.InterfaceName}} struct {
 func ({{.LocalName}} client{{.InterfaceName}}) {{.MethodName}}({{.MethodArguments}}) ({{.MethodResults}}) {
 	{{if .HasContextParam}}
 	if _, ok := {{.ContextParamName}}.Deadline(); !ok {
-		{{.ContextParamName}}, _ = context.WithTimeout({{.ContextParamName}}, DefaultRequestTimeout)
+		tmpctx, c := context.WithTimeout({{.ContextParamName}}, DefaultRequestTimeout)
+		{{.ContextParamName}} = tmpctx
+		defer c()
 	}
 	{{else}}
-	{{.ContextParamName}}, _ := context.WithTimeout(context.Background(), DefaultRequestTimeout)
+	{{.ContextParamName}} := context.Background()
+	{{.ContextParamName}}, c := context.WithTimeout({{.ContextParamName}}, DefaultRequestTimeout)
+	defer c() 
 	{{end}}
 
 	_request := {{.MethodNameLcase}}Request{


### PR DESCRIPTION
@Ayiga 
This set of changes is a small fix to add handling of `context.CancelFunc` returned from `context.WithTimeout`. This set of changes is due to new `go vet` directives added in go1.8 to handle `context.CancelFunc` instead of ignoring them. An example below:

```
go vet ../...
../transport/http/client_gen.go:28: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
exit status 1
```

Please review and let me know what you think on this.